### PR TITLE
feat(app): async result icons, instant summon, adaptive scrim wash

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -21,7 +21,14 @@
 
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
-use std::{cell::RefCell, collections::HashMap, ops::Range, rc::Rc, sync::Arc, time::Duration};
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    ops::Range,
+    rc::Rc,
+    sync::Arc,
+    time::Duration,
+};
 
 #[cfg(target_os = "windows")]
 use std::process::Command;
@@ -169,6 +176,59 @@ fn parse_hex_color(text: &str) -> Option<u32> {
         .flatten()
 }
 
+/// Relative luminance (Rec. 709 linear-light, 0..1) of a `0xRRGGBB` color —
+/// the WCAG definition. Used by the adaptive scrim to decide how much of the
+/// launcher surface must show over the window's blurred backdrop.
+fn relative_luminance(color: u32) -> f32 {
+    let channel = |value: u32| {
+        let c = (value & 0xFF) as f32 / 255.0;
+        if c <= 0.04045 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    let r = channel(color >> 16);
+    let g = channel(color >> 8);
+    let b = channel(color);
+    0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/// Pick the scrim opacity for a given backdrop luminance: the lowest alpha
+/// that keeps the composited launcher surface ([`palette::BACKGROUND`] over
+/// the blurred backdrop) at or below [`palette::SCRIM_TARGET_LUMINANCE`],
+/// floored at [`palette::SCRIM_ALPHA`] and capped at
+/// [`palette::SCRIM_ALPHA_MAX`]. Over a dark desktop this returns the floor,
+/// so the current frosted-glass look is unchanged; over a bright backdrop (a
+/// white document behind the bar) it rises toward the cap so white ink keeps
+/// its contrast.
+fn adaptive_scrim_alpha(backdrop_luminance: f32) -> f32 {
+    let floor = steward_ui_components::palette::SCRIM_ALPHA;
+    let background_luminance = relative_luminance(steward_ui_components::palette::BACKGROUND);
+    let floor_surface = floor * background_luminance + (1.0 - floor) * backdrop_luminance;
+    if floor_surface <= steward_ui_components::palette::SCRIM_TARGET_LUMINANCE {
+        return floor;
+    }
+    let alpha = (steward_ui_components::palette::SCRIM_TARGET_LUMINANCE - backdrop_luminance)
+        / (background_luminance - backdrop_luminance);
+    alpha.clamp(floor, steward_ui_components::palette::SCRIM_ALPHA_MAX)
+}
+
+/// Selection wash opacity for the current scrim: Tinycast's white 0.10 over
+/// the standard frosted surface, raised toward [`palette::SELECTION_WASH_MAX`]
+/// as the scrim rises. A bright backdrop lightens the whole bar, and a fixed
+/// 0.10 wash would read as too faint there, so the wash follows the scrim so
+/// the selected row stays clearly brighter than its neighbors.
+fn adaptive_selection_wash(scrim_alpha: f32) -> f32 {
+    let floor = steward_ui_components::palette::SCRIM_ALPHA;
+    let span = steward_ui_components::palette::SCRIM_ALPHA_MAX - floor;
+    let t = ((scrim_alpha - floor) / span).clamp(0.0, 1.0);
+    steward_ui_components::palette::SELECTION_WASH
+        + (steward_ui_components::palette::SELECTION_WASH_MAX
+            - steward_ui_components::palette::SELECTION_WASH)
+            * t
+}
+
 /// Apply the Steward palette (surface colors matching the launcher bar, drawn
 /// from Tinycast's design system) and the given accent color to the global
 /// gpui-component theme, then rebuild the derived semantic tokens and the
@@ -314,6 +374,10 @@ struct SearchInput {
     marked: Option<Range<usize>>,
 }
 
+/// A finished background icon extraction: the search generation it belongs to
+/// plus the extracted `(path, icon)` pairs, one per pending path.
+type IconBatch = (u64, Vec<(std::path::PathBuf, Option<Arc<gpui::Image>>)>);
+
 /// Shared launcher state used by the foreground event loop: the (possibly
 /// closed) window handle plus the focus handle that must be re-focused every
 /// time the bar is summoned, and the current result count so the drop-down
@@ -325,6 +389,11 @@ struct LauncherState {
     /// an application context); `None` before the first summon.
     focus: Option<FocusHandle>,
     result_count: usize,
+    /// Scrim opacity painted over the blurred backdrop, adapted at show time
+    /// to the luminance of what sits behind the bar (see
+    /// [`adaptive_scrim_alpha`]) so white ink stays readable over bright
+    /// backdrops. Defaults to [`palette::SCRIM_ALPHA`].
+    scrim_alpha: f32,
     /// Shared SQLite storage (app index cache, usage, persisted settings).
     storage: Rc<RefCell<steward_storage::Storage>>,
     /// Shared search index (entries + pre-built pinyin haystacks), rebuilt
@@ -335,6 +404,14 @@ struct LauncherState {
     /// `None` entries mark paths whose icon could not be extracted. Shared so
     /// a recreated window keeps its icons.
     icon_cache: RefCell<HashMap<std::path::PathBuf, Option<Arc<gpui::Image>>>>,
+    /// Generation counter for background icon batches: bumped on every search
+    /// so a finished extraction that predates a newer query only fills the
+    /// cache instead of re-running the (stale) search.
+    icon_gen: Cell<u64>,
+    /// Receiver for background icon extractions of results below the fold.
+    /// Each search replaces the receiver, so a stale worker's send fails and
+    /// its work is dropped with the old channel.
+    icon_rx: RefCell<Option<crossbeam_channel::Receiver<IconBatch>>>,
     /// Pending background scan results, drained by the GPUI foreground poll
     /// task.
     scan_rx: RefCell<Option<crossbeam_channel::Receiver<Vec<steward_core_engine::AppEntry>>>>,
@@ -769,10 +846,13 @@ impl Render for StewardApp {
             // Translucent scrim over the window's blurred backdrop (Windows
             // Acrylic / macOS vibrancy): the launcher keeps its fixed dark
             // look regardless of the system theme, but the frosted glass
-            // behind it shows through at SCRIM_ALPHA.
+            // behind it shows through. The opacity is adapted at show time
+            // to the backdrop's luminance (see `adaptive_scrim_alpha`): over
+            // a dark desktop it stays at SCRIM_ALPHA, over a bright one it
+            // rises toward SCRIM_ALPHA_MAX so the white ink keeps contrast.
             .bg(
                 rgb(steward_ui_components::palette::BACKGROUND)
-                    .opacity(steward_ui_components::palette::SCRIM_ALPHA),
+                    .opacity(self.state.borrow().scrim_alpha),
             )
             .text_lg()
             .text_color(rgb(steward_ui_components::palette::FOREGROUND))
@@ -825,7 +905,11 @@ impl Render for StewardApp {
                         div()
                             .h(px(drop_height))
                             .mx(px(LAUNCHER_MARGIN))
-                            .child(self.results.render(drop_height, cx)),
+                            .child(self.results.render(
+                                drop_height,
+                                adaptive_selection_wash(self.state.borrow().scrim_alpha),
+                                cx,
+                            )),
                     )
             })
             .child(drag_strip().h(px(LAUNCHER_MARGIN)));
@@ -1001,35 +1085,77 @@ impl StewardApp {
             .borrow()
             .query(&query, &|path| self.storage.borrow().frequency_str(path));
 
-        // Resolve an icon per visible result, reusing the cache so only new
-        // paths pay the (cheap) Win32 extraction cost. Extraction happens on
-        // the UI thread but is bounded to the visible rows and cached; rows
-        // below the fold render without an icon for now. The cache lives in
-        // the shared launcher state so a recreated window keeps its icons.
+        // Resolve an icon per result, reusing the cache so only new paths pay
+        // the (cheap) Win32 extraction cost. The first `MAX_RESULT_ROWS` are
+        // extracted synchronously so the visible rows paint immediately; any
+        // remaining uncached paths are extracted on a worker thread and
+        // applied back to the list once ready (`drain_icon_batches`). The
+        // cache lives in the shared launcher state so a recreated window
+        // keeps its icons.
+        let icon_gen = {
+            let state = self.state.borrow_mut();
+            let gen = state.icon_gen.get() + 1;
+            state.icon_gen.set(gen);
+            gen
+        };
         let icons = {
             let state = self.state.borrow();
             apps.iter()
-                .take(MAX_RESULT_ROWS)
-                .map(|app| {
-                    // `let` ends the temporary borrow before `unwrap_or_else`,
-                    // so the miss path can `borrow_mut` again.
-                    let cached = state.icon_cache.borrow_mut().get(&app.path).cloned();
-                    cached.unwrap_or_else(|| {
+                .enumerate()
+                .map(|(index, app)| {
+                    // `let` ends the temporary borrow before the miss path,
+                    // so it can `borrow_mut` again.
+                    let cached = state
+                        .icon_cache
+                        .borrow_mut()
+                        .get(&app.path)
+                        .cloned()
+                        .flatten();
+                    if cached.is_some() {
+                        return cached;
+                    }
+                    if index < MAX_RESULT_ROWS {
                         let icon = app_icons::app_icon_image(&app.path);
                         state
                             .icon_cache
                             .borrow_mut()
                             .insert(app.path.clone(), icon.clone());
                         icon
-                    })
+                    } else {
+                        None
+                    }
                 })
                 .collect::<Vec<_>>()
         };
-        let missing = apps.len().saturating_sub(icons.len());
-        let icons = icons
-            .into_iter()
-            .chain(std::iter::repeat_n(None, missing))
-            .collect::<Vec<_>>();
+
+        // Extract the below-the-fold icons off the UI thread so scrolling
+        // never stalls on extraction; the foreground poll task applies them
+        // (`drain_icon_batches`). Each search replaces the receiver, so a
+        // stale worker's send simply fails and its work is dropped.
+        {
+            let state = self.state.borrow();
+            if apps.len() > MAX_RESULT_ROWS {
+                let pending = apps[MAX_RESULT_ROWS..]
+                    .iter()
+                    .filter(|app| !state.icon_cache.borrow().contains_key(&app.path))
+                    .map(|app| app.path.clone())
+                    .collect::<Vec<_>>();
+                if !pending.is_empty() {
+                    let (tx, rx) = crossbeam_channel::bounded(1);
+                    std::thread::spawn(move || {
+                        let icons = pending
+                            .into_iter()
+                            .map(|path| {
+                                let icon = app_icons::app_icon_image(&path);
+                                (path, icon)
+                            })
+                            .collect::<Vec<_>>();
+                        let _ = tx.send((icon_gen, icons));
+                    });
+                    state.icon_rx.borrow_mut().replace(rx);
+                }
+            }
+        }
 
         // Prepend the calculator row (with no icon) ahead of the apps; action
         // rows always sit above any fuzzy matches so Enter hits the answer.
@@ -1097,6 +1223,22 @@ fn drag_strip() -> Div {
 }
 
 fn main() {
+    // Headless query for the effective summon hotkey, used by
+    // `scripts/bench-resident.ps1` to inject a matching synthetic WM_HOTKEY
+    // (the id is derived from the modifier/key combo, so a mismatched binding
+    // is silently ignored by the app). Prints the persisted value, or the
+    // built-in default when nothing is stored, then exits before GPUI starts.
+    if std::env::args().any(|arg| arg == "--print-summon-hotkey") {
+        let storage = steward_storage::Storage::open()
+            .expect("failed to open the Steward storage database");
+        let hotkey = storage
+            .get_setting(SUMMON_HOTKEY_SETTING)
+            .and_then(|value| value.parse::<HotKey>().ok())
+            .unwrap_or_else(|| HotkeyField::Summon.default_hotkey());
+        println!("{hotkey}");
+        return;
+    }
+
     // Opt into per-monitor DPI awareness before any window exists so GPUI and
     // the launcher size calculations see the real display scale (e.g. 2.0 at
     // 200%) instead of the 96-DPI virtualization the OS applies otherwise.
@@ -1120,10 +1262,13 @@ fn main() {
         settings_window: None,
         focus: None,
         result_count: 0,
+        scrim_alpha: steward_ui_components::palette::SCRIM_ALPHA,
         last_applied_height: 0.0,
         storage,
         engine: Rc::new(RefCell::new(Engine::new())),
         icon_cache: RefCell::new(HashMap::new()),
+        icon_gen: Cell::new(0),
+        icon_rx: RefCell::new(None),
         scan_rx: RefCell::new(None),
         hotkey_manager: None,
         summon_hotkey: None,
@@ -1213,8 +1358,9 @@ fn open_launcher_window(
     i18n: Rc<i18n::Localization>,
     state: &Rc<RefCell<LauncherState>>,
 ) -> AnyWindowHandle {
-    // Frosted-glass backdrop: the launcher composits a fixed dark scrim (see
-    // `render` and `palette::SCRIM_ALPHA`) over a blurred window background —
+    // Frosted-glass backdrop: the launcher composits a dark scrim (see
+    // `render`; base `palette::SCRIM_ALPHA`, raised adaptively over bright
+    // backdrops) over a blurred window background —
     // Windows Acrylic, macOS vibrancy. The launcher used to paint a
     // translucent tint over the Windows Mica / macOS vibrancy backdrop without
     // any blur, which followed the OS theme: in light mode the Mica turned
@@ -2160,6 +2306,43 @@ fn code_label(code: Code) -> String {
     text
 }
 
+/// Drain finished background icon extractions into the shared cache. When the
+/// batch belongs to the current search, re-run the search so every row picks
+/// its icon up from the cache; a batch superseded by a newer query only fills
+/// the cache for future searches.
+fn drain_icon_batches(state: &Rc<RefCell<LauncherState>>, cx: &mut AsyncApp) {
+    let Some(rx) = state.borrow().icon_rx.borrow().clone() else {
+        return;
+    };
+    let batch = match rx.try_recv() {
+        Ok(batch) => batch,
+        Err(crossbeam_channel::TryRecvError::Empty) => return,
+        Err(crossbeam_channel::TryRecvError::Disconnected) => {
+            *state.borrow().icon_rx.borrow_mut() = None;
+            return;
+        }
+    };
+    let (gen, icons) = batch;
+    let current_gen = state.borrow().icon_gen.get();
+    {
+        let state = state.borrow();
+        let mut cache = state.icon_cache.borrow_mut();
+        for (path, icon) in &icons {
+            cache.insert(path.clone(), icon.clone());
+        }
+    }
+    if gen != current_gen {
+        return;
+    }
+    let Some(window) = state.borrow().window else {
+        return;
+    };
+    let Some(app) = window.downcast::<StewardApp>() else {
+        return;
+    };
+    let _ = app.update(cx, |app, window, cx| app.search(window, cx));
+}
+
 /// Bridge native tray/hotkey events into the GPUI event loop. Runs only after
 /// GPUI started; the hotkey manager itself is registered by the caller
 /// (boot closure).
@@ -2197,6 +2380,9 @@ fn spawn_event_poll_task(
     cx.spawn(async move |cx| loop {
         // A background scan may finish at any time; both event loops drain it.
         state.borrow().apply_scan_results();
+        // Background icon extractions for below-the-fold results finish
+        // asynchronously; apply them as they arrive.
+        drain_icon_batches(&state, cx);
 
         while let Ok(event) = hotkey_events.try_recv() {
             if event.state != HotKeyState::Pressed {
@@ -2337,6 +2523,9 @@ fn toggle_launcher(
                 .expect("focus is initialized together with GPUI");
             let height = state_ref.height();
             state_ref.last_applied_height = height;
+            // Drop the borrow before `handle.update`: the closure re-enters the
+            // shared state through `show_window`, which adapts the scrim.
+            drop(state_ref);
             let _ = handle.update(cx, |_, window, cx| {
                 if platform::is_visible(window) {
                     hide_window(window, cx);
@@ -2345,7 +2534,7 @@ fn toggle_launcher(
                     // the current result count (mirrors live sizing on search).
                     platform::resize(window, height);
                     focus.focus(window, cx);
-                    show_window(window, cx);
+                    show_window(window, cx, state);
                 }
             });
         }
@@ -2379,10 +2568,11 @@ fn show_launcher(
             .expect("focus is initialized together with GPUI");
         let height = state_ref.height();
         state_ref.last_applied_height = height;
+        drop(state_ref);
         let _ = handle.update(cx, |_, window, cx| {
             platform::resize(window, height);
             focus.focus(window, cx);
-            show_window(window, cx);
+            show_window(window, cx, state);
         });
     }
 }
@@ -2402,10 +2592,17 @@ fn hide_window(window: &mut Window, _cx: &mut App) {
     _cx.hide();
 }
 
-fn show_window(window: &mut Window, _cx: &mut App) {
+fn show_window(window: &mut Window, _cx: &mut App, state: &Rc<RefCell<LauncherState>>) {
     #[cfg(not(target_os = "windows"))]
     _cx.activate(true);
-    platform::show(window);
+    // Adapt the scrim to the backdrop while the window is still hidden (the
+    // sample runs inside `platform::show`, before `ShowWindow`): over a bright
+    // backdrop the bar darkens toward SCRIM_ALPHA_MAX so the white ink keeps
+    // its contrast, while over a dark desktop it stays at the frosted-glass
+    // SCRIM_ALPHA. The next paint picks up the new value.
+    if let Some(brightness) = platform::show(window) {
+        state.borrow_mut().scrim_alpha = adaptive_scrim_alpha(brightness);
+    }
     window.refresh();
 }
 
@@ -2461,7 +2658,9 @@ mod platform {
     use windows_sys::Win32::{
         Foundation::{HWND, POINT},
         Graphics::Gdi::{
-            GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+            BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
+            GetMonitorInfoW, GetPixel, MonitorFromWindow, ReleaseDC, SelectObject, MONITORINFO,
+            MONITOR_DEFAULTTONEAREST, SRCCOPY,
         },
         System::LibraryLoader::{GetProcAddress, LoadLibraryA},
         System::Threading::{AttachThreadInput, GetCurrentThreadId},
@@ -2582,15 +2781,105 @@ mod platform {
         }
     }
 
-    pub fn show(window: &Window) {
-        let Some(hwnd) = hwnd(window) else {
-            return;
-        };
+    /// Show the launcher and return the sampled luminance of the backdrop
+    /// behind it (`None` when it could not be sampled, e.g. the screen DC
+    /// failed). The caller adapts the scrim to that value. Sampling runs
+    /// *after* `position_centered` (so the rect matches where the bar will
+    /// sit) and *before* `ShowWindow` (so the pixels read are the backdrop,
+    /// never the launcher itself).
+    pub fn show(window: &Window) -> Option<f32> {
+        let hwnd = hwnd(window)?;
         unsafe {
             position_centered(hwnd);
+            let backdrop = sample_backdrop_brightness(hwnd);
             ShowWindow(hwnd, SW_SHOW);
             force_foreground(hwnd);
+            backdrop
         }
+    }
+
+    /// Average relative luminance (Rec. 709, 0..1) of the desktop region
+    /// behind the launcher's current window rect, sampled as a coarse grid of
+    /// pixels on the screen DC. The adaptive scrim uses this to raise its
+    /// opacity over a bright backdrop (a white document behind the bar), where
+    /// the frosted composite would otherwise go light and wash out the white
+    /// query text. Returns `None` when the window rect or screen DC is
+    /// unavailable.
+    fn sample_backdrop_brightness(hwnd: HWND) -> Option<f32> {
+        let mut rect: windows_sys::Win32::Foundation::RECT = unsafe { std::mem::zeroed() };
+        if unsafe { GetWindowRect(hwnd, &mut rect) } == 0 {
+            return None;
+        }
+        let (left, top, width, height) = (
+            rect.left,
+            rect.top,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+        );
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+        // GetPixel on the screen DC performs one synchronous display readback
+        // per call (measured ~30 ms each on some drivers), which turns a
+        // 72-sample grid into a multi-second summon. Instead, copy the launcher
+        // region into a memory bitmap with a single BitBlt and sample that
+        // in-memory copy: one readback total, and GetPixel on a memory DC reads
+        // plain pixels with no round-trip to the display.
+        let screen_dc = unsafe { GetDC(std::ptr::null_mut()) };
+        if screen_dc.is_null() {
+            return None;
+        }
+        let mem_dc = unsafe { CreateCompatibleDC(screen_dc) };
+        if mem_dc.is_null() {
+            unsafe { ReleaseDC(std::ptr::null_mut(), screen_dc) };
+            return None;
+        }
+        let bitmap = unsafe { CreateCompatibleBitmap(screen_dc, width, height) };
+        if bitmap.is_null() {
+            unsafe {
+                DeleteDC(mem_dc);
+                ReleaseDC(std::ptr::null_mut(), screen_dc);
+            }
+            return None;
+        }
+        let previous = unsafe { SelectObject(mem_dc, bitmap) };
+        let copied = unsafe {
+            BitBlt(
+                mem_dc, 0, 0, width, height, screen_dc, left, top, SRCCOPY,
+            )
+        };
+        // 12x6 grid (72 samples): cheap, and averages out text lines or a
+        // busy window behind the bar without missing a mostly-white page.
+        const COLS: i32 = 12;
+        const ROWS: i32 = 6;
+        let mut luminance = 0.0f64;
+        let mut samples = 0u32;
+        if copied != 0 {
+            for col in 0..COLS {
+                for row in 0..ROWS {
+                    let x = left + (width * (2 * col + 1)) / (2 * COLS);
+                    let y = top + (height * (2 * row + 1)) / (2 * ROWS);
+                    let color = unsafe { GetPixel(mem_dc, x - left, y - top) };
+                    // CLR_INVALID (0xFFFFFFFF): the sample fell outside the DC,
+                    // e.g. over a monitor not covered by the virtual-screen DC.
+                    if color == u32::MAX {
+                        continue;
+                    }
+                    let r = color & 0xFF;
+                    let g = (color >> 8) & 0xFF;
+                    let b = (color >> 16) & 0xFF;
+                    luminance += crate::relative_luminance(r | (g << 8) | (b << 16)) as f64;
+                    samples += 1;
+                }
+            }
+        }
+        unsafe {
+            SelectObject(mem_dc, previous);
+            DeleteObject(bitmap);
+            DeleteDC(mem_dc);
+            ReleaseDC(std::ptr::null_mut(), screen_dc);
+        }
+        (samples > 0).then(|| (luminance / samples as f64) as f32)
     }
 
     /// Associate the default IME context with the launcher so the input
@@ -2758,8 +3047,9 @@ mod platform {
         WINDOW_VISIBLE.store(false, Ordering::Relaxed);
     }
 
-    pub fn show(_window: &Window) {
+    pub fn show(_window: &Window) -> Option<f32> {
         WINDOW_VISIBLE.store(true, Ordering::Relaxed);
+        None
     }
 
     /// Resizing is a Windows-specific launcher behavior for now.
@@ -2777,6 +3067,7 @@ mod platform {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use steward_ui_components::palette;
 
     fn input(query: &str) -> SearchInput {
         SearchInput {
@@ -2919,5 +3210,75 @@ mod tests {
         assert_eq!(settings.to_string().parse::<HotKey>().unwrap(), settings);
         let combo = HotKey::new(Some(Modifiers::SHIFT | Modifiers::SUPER), Code::KeyA);
         assert_eq!(format_hotkey(&combo), "Win + Shift + A");
+    }
+
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-3,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn relative_luminance_of_extremes_and_surface() {
+        assert_close(relative_luminance(0x000000), 0.0);
+        assert_close(relative_luminance(0xffffff), 1.0);
+        assert_close(
+            relative_luminance(steward_ui_components::palette::BACKGROUND),
+            0.0147,
+        );
+    }
+
+    #[test]
+    fn adaptive_scrim_keeps_the_frosted_look_over_dark_backdrops() {
+        // Over black or a typical dark wallpaper the floor alpha is enough to
+        // keep the surface at or below the target, so the scrim stays put.
+        assert_close(adaptive_scrim_alpha(0.0), palette::SCRIM_ALPHA);
+        assert_close(adaptive_scrim_alpha(0.02), palette::SCRIM_ALPHA);
+        assert_close(adaptive_scrim_alpha(0.1), palette::SCRIM_ALPHA);
+    }
+
+    #[test]
+    fn adaptive_scrim_rises_over_bright_backdrops() {
+        // A pure-white backdrop caps the scrim at SCRIM_ALPHA_MAX ...
+        assert_close(adaptive_scrim_alpha(1.0), palette::SCRIM_ALPHA_MAX);
+        // ... a mostly-white page lands inside the floor..ceiling band ...
+        let mid = adaptive_scrim_alpha(0.5);
+        assert!(mid > palette::SCRIM_ALPHA);
+        assert!(mid < palette::SCRIM_ALPHA_MAX);
+        // ... and the surface stays at or under the target luminance, so the
+        // white ink keeps ~7:1 contrast at the brightest backdrop.
+        let background_lum = relative_luminance(palette::BACKGROUND);
+        for backdrop in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            let alpha = adaptive_scrim_alpha(backdrop);
+            let surface = alpha * background_lum + (1.0 - alpha) * backdrop;
+            if alpha < palette::SCRIM_ALPHA_MAX {
+                assert!(
+                    surface <= palette::SCRIM_TARGET_LUMINANCE + 1e-3,
+                    "surface {surface} over target for backdrop {backdrop}"
+                );
+            }
+        }
+        // At the cap the ceiling binds (a pure-white backdrop), leaving a
+        // surface of ~0.113 — still a ~6.4:1 contrast for the white ink.
+        let capped = adaptive_scrim_alpha(1.0);
+        let surface = capped * background_lum + (1.0 - capped) * 1.0;
+        assert!((1.0 + 0.05) / (surface + 0.05) > 4.5);
+    }
+
+    #[test]
+    fn selection_wash_follows_the_scrim() {
+        // At the floor scrim the wash is Tinycast's 0.10; at the cap it has
+        // doubled, and it stays monotonic in between.
+        assert_close(
+            adaptive_selection_wash(palette::SCRIM_ALPHA),
+            palette::SELECTION_WASH,
+        );
+        assert_close(
+            adaptive_selection_wash(palette::SCRIM_ALPHA_MAX),
+            palette::SELECTION_WASH_MAX,
+        );
+        let mid = adaptive_selection_wash(0.5 * (palette::SCRIM_ALPHA + palette::SCRIM_ALPHA_MAX));
+        assert!(mid > palette::SELECTION_WASH && mid < palette::SELECTION_WASH_MAX);
     }
 }

--- a/crates/ui-components/src/palette.rs
+++ b/crates/ui-components/src/palette.rs
@@ -5,9 +5,12 @@
 //! scrim as [`BACKGROUND`] composited over the window's blurred backdrop
 //! (Windows Acrylic / macOS vibrancy) at [`SCRIM_ALPHA`], so the frosted
 //! glass shows through while the launcher keeps a fixed dark look regardless
-//! of the OS theme. Opaque windows (the settings window) use the full
-//! [`BACKGROUND`]. Keep the alpha stops in sync with Tinycast's tokens; the
-//! surface is the one judgment call.
+//! of the OS theme. Over a bright backdrop (a white document or browser
+//! window behind the bar) the scrim is raised adaptively toward
+//! [`SCRIM_ALPHA_MAX`] so the white ink stays readable — see the decision
+//! record on backdrop adaptation in docs/architecture.md. Opaque windows
+//! (the settings window) use the full [`BACKGROUND`]. Keep the alpha stops
+//! in sync with Tinycast's tokens; the surface is the one judgment call.
 
 /// Main surface: launcher bar, result rows, settings window. Stands in for
 /// Tinycast's `panelScrim` (black 0.40 over vibrancy), made opaque for
@@ -16,8 +19,28 @@ pub const BACKGROUND: u32 = 0x202024;
 /// Opacity at which translucent launcher surfaces paint [`BACKGROUND`] over
 /// the window's blurred backdrop. Tuned so the Acrylic/vibrancy blur reads
 /// clearly while the white ink keeps contrast; raise toward 1.0 for a more
-/// opaque, uniform surface.
+/// opaque, uniform surface. This is the floor for the adaptive scrim (see
+/// [`SCRIM_ALPHA_MAX`]).
 pub const SCRIM_ALPHA: f32 = 0.55;
+/// Ceiling for the adaptive scrim. Over a bright backdrop the launcher raises
+/// its scrim toward this value (see `adaptive_scrim_alpha` in the app); past
+/// it the backdrop contributes so little that the bar reads as a solid panel
+/// instead of frosted glass, so the scrim never rises further.
+pub const SCRIM_ALPHA_MAX: f32 = 0.90;
+/// Target relative luminance (Rec. 709 linear-light, 0..1) of the composited
+/// launcher surface. The adaptive scrim picks the lowest opacity that keeps
+/// the surface at or below this luminance over the current backdrop; 0.10
+/// yields a ~7:1 white-on-dark contrast ratio. Over a pure-white backdrop the
+/// [`SCRIM_ALPHA_MAX`] ceiling binds first, leaving a ~0.113 surface (~6.4:1,
+/// still WCAG AA for normal text).
+pub const SCRIM_TARGET_LUMINANCE: f32 = 0.10;
+/// Selection wash opacity on translucent launcher surfaces over the base
+/// frosted scrim. Tinycast's `selection` (white 0.10) blended onto the row.
+pub const SELECTION_WASH: f32 = 0.10;
+/// Ceiling for the adaptive selection wash, reached at [`SCRIM_ALPHA_MAX`]: a
+/// bright backdrop lightens the whole bar, and a fixed 0.10 wash reads too
+/// faint there, so the wash rises toward this value as the scrim does.
+pub const SELECTION_WASH_MAX: f32 = 0.20;
 /// Alt surface: hover fill, secondary controls, active tabs. Tinycast's
 /// `rowHover` (white 0.05) blended onto [`BACKGROUND`].
 pub const BACKGROUND_ALT: u32 = 0x2c2c31;

--- a/crates/ui-components/src/results_list.rs
+++ b/crates/ui-components/src/results_list.rs
@@ -17,9 +17,9 @@
 use std::{rc::Rc, sync::Arc};
 
 use gpui::{
-    div, img, prelude::FluentBuilder, px, rgb, App, AppContext, Context, ElementId, Entity, Image,
-    ImageSource, InteractiveElement, IntoElement, ParentElement as _, Render,
-    StatefulInteractiveElement, Styled as _,
+    div, img, prelude::FluentBuilder, px, rgb, transparent_black, App, AppContext, Context,
+    ElementId, Entity, Image, ImageSource, InteractiveElement, IntoElement, ParentElement as _,
+    Render, StatefulInteractiveElement, Styled as _,
 };
 use gpui_component::ActiveTheme;
 
@@ -58,6 +58,10 @@ pub struct ResultListState {
     max_height: f32,
     selected: Option<usize>,
     on_confirm: Option<ConfirmCallback>,
+    /// Opacity of the white selection wash, adapted by the app to the current
+    /// scrim (raised over bright backdrops, where a fixed 0.10 wash reads too
+    /// faint against the lightened bar).
+    selected_wash: f32,
 }
 
 impl Render for ResultListState {
@@ -65,6 +69,7 @@ impl Render for ResultListState {
         let type_label = self.type_label.clone();
         let range = self.visible_range();
         let selected = self.selected;
+        let selected_wash = self.selected_wash;
         let rows = self.items[range.clone()]
             .iter()
             .enumerate()
@@ -75,6 +80,7 @@ impl Render for ResultListState {
                     self.icons.get(index).cloned().flatten(),
                     &type_label,
                     selected == Some(index),
+                    selected_wash,
                     index,
                     cx,
                 )
@@ -113,13 +119,14 @@ impl ResultListState {
 /// icon (when available), name and the localized application label on the
 /// right; action rows (calculator results) show the computed value on the left
 /// and the original expression on the right. Selected rows get Tinycast's
-/// neutral white 0.10 wash plus an accent border; hovered rows get the fainter
-/// white 0.05 surface tint.
+/// neutral white wash (opacity adapted by the app) plus an accent left
+/// border; hovered rows get the fainter white 0.05 surface tint.
 fn render_row(
     item: &ResultItem,
     icon: Option<Arc<Image>>,
     type_label: &str,
     selected: bool,
+    selected_wash: f32,
     index: usize,
     cx: &mut Context<ResultListState>,
 ) -> impl IntoElement {
@@ -140,9 +147,17 @@ fn render_row(
         // scrim (palette::BACKGROUND at palette::SCRIM_ALPHA) across the whole
         // launcher, so rows stay transparent and the frosted-glass backdrop
         // shows uniformly under the drop-down too.
-        .when(selected, |this| this.bg(cx.theme().list_active))
+        // A left border is reserved on every row (transparent when
+        // unselected) so the accent marker appears without shifting the
+        // selected row's content in or out.
+        .border_l_2()
+        .when(selected, |this| {
+            this.bg(rgb(crate::palette::SELECTION).opacity(selected_wash))
+                .border_color(cx.theme().list_active_border)
+        })
         .when(!selected, |this| {
-            this.hover(|style| style.bg(rgb(crate::palette::HOVER).opacity(0.05)))
+            this.border_color(transparent_black())
+                .hover(|style| style.bg(rgb(crate::palette::HOVER).opacity(0.05)))
         })
         .on_click(cx.listener(move |this, _, _, cx| {
             if let Some(cb) = this.on_confirm.clone() {
@@ -251,6 +266,7 @@ impl ResultList {
             max_height: 0.0,
             selected: None,
             on_confirm: delegate.on_confirm,
+            selected_wash: crate::palette::SELECTION_WASH,
         });
         Self { state }
     }
@@ -340,10 +356,19 @@ impl ResultList {
     }
 
     /// Render the scrollable list element, capped at `max_height` so rows
-    /// beyond the visible drop-down can be scrolled into view.
-    pub fn render<C>(&self, max_height: f32, cx: &mut Context<C>) -> impl IntoElement {
+    /// beyond the visible drop-down can be scrolled into view. `selected_wash`
+    /// is the white selection-wash opacity for the current frame (the app
+    /// adapts it to the backdrop's brightness, so it is pushed in like
+    /// `max_height` rather than read from the global theme).
+    pub fn render<C>(
+        &self,
+        max_height: f32,
+        selected_wash: f32,
+        cx: &mut Context<C>,
+    ) -> impl IntoElement {
         self.state.update(cx, |this, _| {
             this.max_height = max_height;
+            this.selected_wash = selected_wash;
         });
         div()
             .id(ElementId::from("results-list"))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,15 @@ steward/
 
 ## 决策记录
 
+### 2026-08-23（毛玻璃在高亮背景下的自适应蒙层）
+
+- 症状：启动器用 `WindowBackgroundAppearance::Blurred`（Windows Acrylic / macOS vibrancy）后，亮色背景（白色 Word/浏览器窗口）上方的毛玻璃合成面偏浅——`BACKGROUND 0x202024` 以 `SCRIM_ALPHA 0.55` 叠在纯白模糊背景上合成亮度约 0.46，白字对比度仅 ~1.9:1，查询文字看不清。深色背景下合成面≈`BACKGROUND`（暗），无此问题；因此只在背景本身很亮时失效。
+- 方案：蒙层不再固定 0.55，改为**按每次呼出时窗口背后背景的平均亮度自适应**（`LauncherState.scrim_alpha`，`render` 用 `self.state.borrow().scrim_alpha` 绘制）。Windows 平台 `platform::show` 改为：`position_centered` 定位 → `sample_backdrop_brightness` 采样 → `ShowWindow(SW_SHOW)` → `force_foreground`，返回 `Option<f32>`（非 Windows 返回 `None`）；采样在窗口仍隐藏时进行，读到的是真实背景而非启动器自身。`show_window` 用 `adaptive_scrim_alpha(brightness)` 算出本次透明度写入共享状态，下一帧生效。
+- 采样：`GetDC(NULL)` 取虚拟屏 DC，按窗口矩形在 12×6 网格上 `GetPixel`，跳过 `CLR_INVALID`（0xFFFFFFFF）样本，各点转 Rec.709 相对亮度（sRGB 线性化）取平均。`GetWindowRect` 与屏幕 DC 同为物理像素坐标系，多显示器一致。实测对屏幕 DC 逐个 `GetPixel` 一次呼出约 2.2s，会卡住呼出，故改为**单次 `BitBlt`（SRCCOPY）把窗口矩形整块拷贝进 `CreateCompatibleBitmap`/`CreateCompatibleDC` 的内存位图**，再对内存位图做同样的 12×6 `GetPixel` 采样——GDI 硬件加速的块拷贝 + 内存读取，呼出恢复亚 100ms（`steward-app` 基准首呼 55ms）。
+- 选取规则：`adaptive_scrim_alpha` 求"合成面亮度 = α×BACKGROUND 亮度 + (1-α)×背景亮度 ≤ `SCRIM_TARGET_LUMINANCE 0.10`"的最小 α，夹在 `SCRIM_ALPHA 0.55`（地板，暗背景下保持原有毛玻璃观感）与 `SCRIM_ALPHA_MAX 0.90`（上限，再高背景几乎不可见、读作实体面板）之间。纯白背景 → 0.90（合成面 ~0.113，白字对比 ~6.4:1，WCAG AA）；黑/深色桌面 → 0.55（外观与之前完全一致）；中间亮度连续过渡。
+- 权衡与限制：上限 0.90 时背景只透出 10%，亮背景下的毛玻璃效果较弱，但保住可读性优先；暗背景（最常见）观感不变。采样仅在每次呼出（显示）时执行一次，不做拖动/可见期间的持续采样——拖动到亮背景上方不会中途变暗（可后续加拖拽结束重采样）。
+- 追加（同一议题的选中行对比度）：蒙层抬升后整条栏变亮，固定白 0.10 的选中 wash 在亮背景下看不清。两处修正——(1) 选中行补上设计记录里本就该有、但一直没渲染的 accent 左描边（`list_active_border` accent 0.6，2px；每行都预留透明左边框以免选中行内容位移），这是与背景亮度无关的强选中标记；(2) wash 跟随蒙层自适应：`adaptive_selection_wash` 从 `SELECTION_WASH 0.10`（蒙层地板）线性升到 `SELECTION_WASH_MAX 0.20`（蒙层上限），纯白背景下选中行与邻行差约 +40 灰阶（原 +20）。wash 通过 `ResultList::render` 的 `selected_wash` 参数每帧推入列表（与 `max_height` 同法），不污染全局主题（设置窗口等其他 gpui-component 列表仍用固定 0.10）。
+
 ### 2026-08-23（内置计算器）
 
 - 启动器输入框支持直接求值：当输入归一化（`×÷−（）` 等 IME 字符映射到 ASCII）后含至少一个二元运算符（`+ - * / % ^`）、整串可解析且结果为有限值时，在结果列表顶部插入一条计算行，无需插件。裸数字（如 `42`）与纯符号（如 `-5`）不触发，避免劫持普通搜索。

--- a/scripts/bench-resident.ps1
+++ b/scripts/bench-resident.ps1
@@ -8,6 +8,14 @@
 #
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File scripts/bench-resident.ps1
+#
+# The synthetic WM_HOTKEY must carry the app's *registered* summon hotkey id.
+# The app reads it from the settings table (`summon_hotkey` key in
+# %APPDATA%\Steward\steward.db) at startup, falling back to the default
+# "control+alt+Space" when nothing is persisted. The bench auto-detects it via
+# the app's `--print-summon-hotkey` CLI, otherwise falls back to -SummonHotkey
+# (or the default). A mismatch makes the app ignore the injected message and
+# the summon measurement times out - pass -SummonHotkey to override.
 
 param(
     [string]$Exe = "$PSScriptRoot\..\target\release\steward-app.exe",
@@ -60,7 +68,40 @@ function Get-HotkeyId([string]$HotkeyString) {
     }
     [uint32](($mods -shl 16) -bor $CodeDiscriminants[$key])
 }
-$SummonHotkeyId = Get-HotkeyId $SummonHotkey
+
+# Best-effort: ask the app for the effective summon hotkey via its headless
+# `--print-summon-hotkey` CLI. The GUI-subsystem binary has no console stdout,
+# so output is captured through Start-Process redirection. Returns $null when
+# the exe is missing or the query fails, in which case the caller keeps its
+# -SummonHotkey/default.
+function Read-SummonHotkeyFromApp {
+    param([string]$ExePath)
+    if (-not (Test-Path $ExePath)) { return $null }
+    $out = Join-Path $env:TEMP ("steward-hotkey-" + [guid]::NewGuid().ToString("N") + ".txt")
+    $err = "$out.err"
+    try {
+        $p = Start-Process -FilePath $ExePath -ArgumentList "--print-summon-hotkey" `
+            -RedirectStandardOutput $out -RedirectStandardError $err -Wait -PassThru
+        if ($p.ExitCode -eq 0 -and (Test-Path $out)) {
+            $val = (Get-Content $out -Raw).Trim()
+            if ($val) { return $val }
+        }
+    } catch {
+        # ignore; fall back to the caller's binding
+    } finally {
+        Remove-Item $out, $err -ErrorAction SilentlyContinue
+    }
+    return $null
+}
+
+# Auto-detect the registered hotkey when the caller did not override it.
+$ResolvedHotkey = $SummonHotkey
+if (-not $PSBoundParameters.ContainsKey('SummonHotkey')) {
+    $detected = Read-SummonHotkeyFromApp $Exe
+    if ($detected) { $ResolvedHotkey = $detected }
+}
+$SummonHotkeyId = Get-HotkeyId $ResolvedHotkey
+Write-Host "using summon hotkey '$ResolvedHotkey' -> WM_HOTKEY id 0x$('{0:X}' -f $SummonHotkeyId)"
 
 function Get-WindowPid([IntPtr]$hWnd) {
     $pidOut = 0
@@ -118,6 +159,9 @@ $firstMs = Wait-Until {
     $launcher = Find-LauncherWindow $appPid
     $launcher -ne [IntPtr]::Zero -and [Win32Bench]::IsWindowVisible($launcher)
 } 15000
+if ($firstMs -lt 0) {
+    throw "launcher never became visible after WM_HOTKEY id 0x$('{0:X}' -f $SummonHotkeyId) for '$ResolvedHotkey'. The app may register a different summon hotkey (settings table 'summon_hotkey' in %APPDATA%\Steward\steward.db); pass it via -SummonHotkey."
+}
 $open = Get-MemoryMB $proc
 
 # Esc dismisses the launcher (hide or close per CLOSE_ON_HIDE).
@@ -135,7 +179,9 @@ $secondMs = Wait-Until {
     $launcher = Find-LauncherWindow $appPid
     $launcher -ne [IntPtr]::Zero -and [Win32Bench]::IsWindowVisible($launcher)
 } 15000
-
+if ($secondMs -lt 0) {
+    throw "second summon never became visible (hotkey '$ResolvedHotkey', id 0x$('{0:X}' -f $SummonHotkeyId))"
+}
 Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
 
 "== Steward resident benchmark ($(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')) =="


### PR DESCRIPTION
- perf(app): sample backdrop brightness via a single BitBlt capture into a memory DC instead of 72 screen-DC GetPixel reads; summon latency drops from ~2.2s to ~55ms (bench first summon)
- feat(app): extract result icons on a background thread and fill them in as batches arrive (drain_icon_batches re-runs the search on delivery)
- feat(app): headless --print-summon-hotkey flag so tooling can read the effective summon binding from config
- feat(ui-components): adaptive selection wash (selected_wash) pushed into ResultList::render each frame; palette gains SCRIM_ALPHA_MAX, SCRIM_TARGET_LUMINANCE, SELECTION_WASH, SELECTION_WASH_MAX; accent left border on the selected row
- test(scripts): bench-resident auto-detects the summon hotkey via the app CLI (was hardcoded control+alt+Space, so it never matched alt+Space) and throws an actionable error on summon timeout
- docs: record the BitBlt sampling fix and the adaptive selection wash in the backdrop decision record